### PR TITLE
Add Allowlist Support

### DIFF
--- a/UnlimitedPlayers/Events/Multiplayer/ConnectionEvents.cs
+++ b/UnlimitedPlayers/Events/Multiplayer/ConnectionEvents.cs
@@ -12,22 +12,37 @@ namespace UnlimitedPlayers.Events.Multiplayer
     {
       List<string> clientMods = new List<string>();
       List<string> denylistMods = new List<string>();
+      List<string> allowlistMods = new List<string>();
+      List<string> notAllowlistedMods = new List<string>();
 
       foreach (IMultiplayerPeerMod mod in e.Peer.Mods)
       {
         clientMods.Add(mod.ID);
         if (LazyHelper.ClientModsDenylist.Contains(mod.ID))
           denylistMods.Add(mod.ID);
+        if (LazyHelper.ClientModsAllowlist.Contains(mod.ID))
+          allowlistMods.Add(mod.ID);
+        else if (LazyHelper.ClientModsAllowlist.Count > 0)
+          notAllowlistedMods.Add(mod.ID);
       }
 
       string clientModsStr = string.Join(", ", clientMods);
       string deniedModsStr = string.Join(", ", denylistMods);
+      string allowedModsStr = string.Join(", ", allowlistMods);
+      string notAllowlistedModsStr = string.Join(", ", notAllowlistedMods);
 
       if (clientMods.Count > 0) {
         LazyHelper.LogInfo($"Peer {e.Peer.PlayerID} uses mods: {clientModsStr}");
       }
+      if (allowlistMods.Count > 0) {
+        LazyHelper.LogInfo($"Peer {e.Peer.PlayerID} has allowlisted mods: {allowedModsStr}");
+      }
       if (denylistMods.Count > 0) {
         LazyHelper.LogWarn($"Peer {e.Peer.PlayerID} kicked for using illegal mods: {deniedModsStr}");
+        Game1.server.kick(e.Peer.PlayerID);
+      }
+      else if (LazyHelper.ClientModsAllowlist.Count > 0 && notAllowlistedMods.Count > 0) {
+        LazyHelper.LogWarn($"Peer {e.Peer.PlayerID} kicked for using non-allowlisted mods: {notAllowlistedModsStr}");
         Game1.server.kick(e.Peer.PlayerID);
       }
     }

--- a/UnlimitedPlayers/LazyHelper.cs
+++ b/UnlimitedPlayers/LazyHelper.cs
@@ -10,6 +10,7 @@ namespace UnlimitedPlayers
   {
     public static int PlayerLimit { get; set; } = 10;
     public static List<string> ClientModsDenylist { get; set; } = new List<string>();
+    public static List<string> ClientModsAllowlist { get; set; } = new List<string>();
     public static IModHelper ModHelper { get; set; }
     public static ModEntry ModEntry { get; set; }
 
@@ -92,6 +93,7 @@ namespace UnlimitedPlayers
     public List<string> Denylist { get; set; } = new List<string>() {
       "CJBok.CheatsMenu", "Ryaon.JunimoKartCheater"
     };
+    public List<string> Allowlist { get; set; } = new List<string>();
   }
 
   public class ConfigParser
@@ -104,6 +106,7 @@ namespace UnlimitedPlayers
     {
       LazyHelper.PlayerLimit = PlayerLimit;
       LazyHelper.ClientModsDenylist = ClientMods.Denylist;
+      LazyHelper.ClientModsAllowlist = ClientMods.Allowlist;
     }
   }
 }

--- a/UnlimitedPlayers/config.json
+++ b/UnlimitedPlayers/config.json
@@ -3,6 +3,7 @@
   "ClientMods": {
     "Denylist": [
       "CJBok.CheatsMenu", "Ryaon.JunimoKartCheater"
-    ]
+    ],
+    "Allowlist": []
   }
 }


### PR DESCRIPTION
# Summary
This PR adds support for a Client Mods Allowlist in addition to the existing denylist functionality.

# Changes
- **Config Update:**
  - `config.json` now supports a `ClientMods.Allowlist` array (empty by default).
- **Code Update:**
  - `LazyHelper` and `ConfigParser` now handle `ClientModsAllowlist` just like the denylist.
  - ConnectionEvents.PeerConnected:
    - Collects and logs allowlisted mods.
    - If the allowlist is non-empty, only allows peers whose mods are all in the allowlist.
    - Kicks peers with mods not in the allowlist (if allowlist is enforced).
    - Still enforces the denylist as before.

# Usage
- To enforce an allowlist, add mod IDs to the `Allowlist` array in `config.json`.
- If the allowlist is empty, all mods are allowed (except those on the denylist).

# Motivation
This allows server hosts to explicitly specify which mods are permitted, improving control and security for multiplayer sessions.